### PR TITLE
chore: use the record type

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"]
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/strict"],
+  "parserOptions": {
+    "project": "tsconfig.json"
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,14 +18,14 @@ export interface PackageJson {
   contributors?: Maintainer[];
   license?: string;
   repository?: Repository;
-  dependencies?: Dependencies;
-  devDependencies?: Dependencies;
-  peerDependencies?: Dependencies;
-  bundleDependencies?: Dependencies;
-  bundledDependencies?: Dependencies;
-  engines?: ObjectOfStrings;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  bundleDependencies?: Record<string, string>;
+  bundledDependencies?: Record<string, string>;
+  engines?: Record<string, string>;
   files?: string[];
-  bin?: {[key: string]: string};
+  bin?: Record<string, string>;
   man?: string|string[];
   directories?:Directories;
   /**
@@ -39,7 +39,7 @@ export interface PackageJson {
   /**
    * npm config values for publish time. like setting an alternate registry
    */
-  publishConfig?:ObjectOfStrings;
+  publishConfig?:Record<string, string>;
 }
 
 // this is what you get from the npm api.
@@ -47,10 +47,10 @@ export interface Packument {
   name: string;
   readme?: string;
   description?: string;
-  'dist-tags': {latest?: string}&ObjectOfStrings;
-  versions: {[key: string]: PackumentVersion};
+  'dist-tags': {latest?: string}&Record<string, string>;
+  versions: Record<string, PackumentVersion>;
   maintainers: Maintainer[];
-  time: {modified: string, created: string, [key: string]: string};
+  time: Record<string, string> & {modified: string; created: string};
   homepage?: string;
   keywords?: string[];
   repository?: Repository;
@@ -69,7 +69,7 @@ export interface PackageLock {
   packageIntegrity?: string;
   preserveSymlinks?: boolean;
   requires?: boolean;
-  dependencies?: {[moduleName: string]: LockDependency};
+  dependencies?: Record<string, LockDependency>;
 }
 
 export type Repository = {
@@ -112,24 +112,24 @@ export interface PackumentVersion extends PackageJson {
 export interface Manifest{
   name:string;
   modified:string;
-  'dist-tags':ObjectOfStrings;
-  versions:{[version:string]:ManifestVersion}
+  'dist-tags':Record<string, string>;
+  versions:Record<string, ManifestVersion>
 }
 
 export interface ManifestVersion{
   name:string;
   version:string;
-  dependencies?:ObjectOfStrings;
-  optionalDependencies?:ObjectOfStrings;
-  devDependencies?:ObjectOfStrings;
-  bundleDependencies?:ObjectOfStrings;
-  bundledDependencies?:ObjectOfStrings;
-  peerDependencies?:ObjectOfStrings;
-  bin?:ObjectOfStrings;
+  dependencies?:Record<string, string>;
+  optionalDependencies?:Record<string, string>;
+  devDependencies?:Record<string, string>;
+  bundleDependencies?:Record<string, string>;
+  bundledDependencies?:Record<string, string>;
+  peerDependencies?:Record<string, string>;
+  bin?:Record<string, string>;
   _hasShrinkwrap?:boolean;
   directories?:Directories;
   dist:Dist;
-  engines:ObjectOfStrings;
+  engines:Record<string, string>;
   deprecated?:string;
 }
 
@@ -167,7 +167,7 @@ export interface Dist {
 }
 
 // https://docs.npmjs.com/misc/scripts
-export type NpmScripts = ObjectOfStrings&{
+export type NpmScripts = Record<string, string>&{
   test?: string;
   pretest?: string;
   posttest?: string;
@@ -204,8 +204,8 @@ export interface LockDependency {
   bundled?: boolean;
   dev?: boolean;
   optional?: boolean;
-  requires?: {[moduleName: string]: string};
-  dependencies?: {[moduleName: string]: LockDependency};
+  requires?: Record<string, string>;
+  dependencies?: Record<string, LockDependency>;
 }
 
 export type Maintainer = {
@@ -213,12 +213,3 @@ export type Maintainer = {
   email?: string;
   url?: string;
 }|string;
-
-
-interface ObjectOfStrings {
-  [key: string]: string;
-}
-
-interface Dependencies {
-  [moduleName: string]: string;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^17.0.31",
+        "@typescript-eslint/eslint-plugin": "^5.26.0",
         "@typescript-eslint/parser": "^4.33.0",
         "eslint": "^7.32.0",
         "gts": "^3.1.0",
@@ -240,35 +241,92 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.26.0.tgz",
+      "integrity": "sha512-oGCmo0PqnRZZndr+KwvvAUvD3kNE4AfyoGCwOZpoCncSh4MVD06JTE8XQa2u9u+NX5CsyZMBTEc2C72zx38eYA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
+        "@typescript-eslint/scope-manager": "5.26.0",
+        "@typescript-eslint/type-utils": "5.26.0",
+        "@typescript-eslint/utils": "5.26.0",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
-        "semver": "^7.3.5",
+        "ignore": "^5.2.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^4.0.0",
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.26.0.tgz",
+      "integrity": "sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/visitor-keys": "5.26.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.26.0.tgz",
+      "integrity": "sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.26.0.tgz",
+      "integrity": "sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.26.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -366,6 +424,32 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.26.0.tgz",
+      "integrity": "sha512-7ccbUVWGLmcRDSA1+ADkDBl5fP87EJt0fnijsMFTVHXKGduYMgienC/i3QwoVhDADUAPoytgjbZbCOMj4TY55A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "5.26.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@typescript-eslint/types": {
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
@@ -404,6 +488,131 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.26.0.tgz",
+      "integrity": "sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.26.0",
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/typescript-estree": "5.26.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.26.0.tgz",
+      "integrity": "sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/visitor-keys": "5.26.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.26.0.tgz",
+      "integrity": "sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.26.0.tgz",
+      "integrity": "sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/visitor-keys": "5.26.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.26.0.tgz",
+      "integrity": "sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.26.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -1665,6 +1874,47 @@
       },
       "peerDependencies": {
         "typescript": ">=3"
+      }
+    },
+    "node_modules/gts/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "4.33.0",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "debug": "^4.3.1",
+        "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
+        "regexpp": "^3.1.0",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^4.0.0",
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gts/node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/hard-rejection": {
@@ -3711,21 +3961,54 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.26.0.tgz",
+      "integrity": "sha512-oGCmo0PqnRZZndr+KwvvAUvD3kNE4AfyoGCwOZpoCncSh4MVD06JTE8XQa2u9u+NX5CsyZMBTEc2C72zx38eYA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
+        "@typescript-eslint/scope-manager": "5.26.0",
+        "@typescript-eslint/type-utils": "5.26.0",
+        "@typescript-eslint/utils": "5.26.0",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
-        "semver": "^7.3.5",
+        "ignore": "^5.2.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.26.0.tgz",
+          "integrity": "sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.26.0",
+            "@typescript-eslint/visitor-keys": "5.26.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.26.0.tgz",
+          "integrity": "sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==",
+          "dev": true
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.26.0.tgz",
+          "integrity": "sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.26.0",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "dev": true
+        },
         "ignore": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -3781,6 +4064,17 @@
         "@typescript-eslint/visitor-keys": "4.33.0"
       }
     },
+    "@typescript-eslint/type-utils": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.26.0.tgz",
+      "integrity": "sha512-7ccbUVWGLmcRDSA1+ADkDBl5fP87EJt0fnijsMFTVHXKGduYMgienC/i3QwoVhDADUAPoytgjbZbCOMj4TY55A==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "5.26.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      }
+    },
     "@typescript-eslint/types": {
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
@@ -3800,6 +4094,80 @@
         "is-glob": "^4.0.1",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.26.0.tgz",
+      "integrity": "sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.26.0",
+        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/typescript-estree": "5.26.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.26.0.tgz",
+          "integrity": "sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.26.0",
+            "@typescript-eslint/visitor-keys": "5.26.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.26.0.tgz",
+          "integrity": "sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.26.0.tgz",
+          "integrity": "sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.26.0",
+            "@typescript-eslint/visitor-keys": "5.26.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.26.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.26.0.tgz",
+          "integrity": "sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.26.0",
+            "eslint-visitor-keys": "^3.3.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+              "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+              "dev": true
+            }
+          }
+        },
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/visitor-keys": {
@@ -4743,6 +5111,30 @@
         "rimraf": "^3.0.2",
         "update-notifier": "^5.0.0",
         "write-file-atomic": "^3.0.3"
+      },
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+          "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/experimental-utils": "4.33.0",
+            "@typescript-eslint/scope-manager": "4.33.0",
+            "debug": "^4.3.1",
+            "functional-red-black-tree": "^1.0.1",
+            "ignore": "^5.1.8",
+            "regexpp": "^3.1.0",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        }
       }
     },
     "hard-rejection": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "devDependencies": {
     "@types/node": "^17.0.31",
+    "@typescript-eslint/eslint-plugin": "^5.26.0",
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.32.0",
     "gts": "^3.1.0",


### PR DESCRIPTION
This is a cosmetic change: Use the standard (since TS 2.1) [`Record<string, string>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type) utility type instead of the custom ObjectOfStrings type.

What I did was:
- In `.eslintrc.json`, replace `plugin:@typescript-eslint/recommended` with `plugin:@typescript-eslint/strict`, which switches on the [consistent-indexed-object-style](https://typescript-eslint.io/rules/consistent-indexed-object-style) rule. I had to [upgrade](https://github.com/typescript-eslint/typescript-eslint/blob/main/CHANGELOG.md#5240-2022-05-16) `@typescript-eslint/eslint-plugin`.
- Run `npm run-script fix`, which edits `index.d.ts`. It replaces, e.g. `{[key: string]: string}` with `Record<string, string>`.