### PR TITLE
fix: allow empty peer dependency metadata

### DIFF
--- a/test/package-json.ts
+++ b/test/package-json.ts
@@ -1,0 +1,18 @@
+import t from 'tap'
+import type { PackageJSON } from '../types/index.d.ts'
+
+t.test('PackageJSON peerDependenciesMeta allows an empty metadata object', (t) => {
+  const pkg: PackageJSON = {
+    name: 'peer-meta-empty',
+    version: '1.0.0',
+    peerDependencies: {
+      react: '^18.0.0',
+    },
+    peerDependenciesMeta: {
+      react: {},
+    },
+  }
+
+  t.same(pkg.peerDependenciesMeta, { react: {} })
+  t.end()
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,7 +30,7 @@ interface Overrides {
 
 // https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependenciesmeta
 interface PeerDependencyMeta {
-  optional: boolean
+  optional?: boolean
 }
 
 // https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license


### PR DESCRIPTION
## Summary
- Make `PeerDependencyMeta.optional` optional so `PackageJSON` accepts empty peer dependency metadata objects.
- Add a type-level regression test covering `peerDependenciesMeta: { react: {} }`.

## Validation
- `npx tap test/package-json.ts`
- `npm run eslint -- test/package-json.ts types/index.d.ts`
- `git diff --check`

## Notes
- `npm test` type-checks successfully but the full run currently fails because live npm registry fixture snapshots for old `uuid` versions changed their `deprecated` text upstream. That snapshot drift is unrelated to this change.