### PR TITLE
feat: add modern package json fields

### DIFF
--- a/test/package-json-fields.ts
+++ b/test/package-json-fields.ts
@@ -1,0 +1,37 @@
+import t from 'tap'
+import type { PackageJSON } from '../types/index.d.ts'
+
+t.test('PackageJSON includes modern package metadata fields', (t) => {
+  const pkg: PackageJSON = {
+    name: 'modern-package-fields',
+    version: '1.0.0',
+    type: 'module',
+    exports: {
+      '.': {
+        import: './dist/index.mjs',
+        require: './dist/index.cjs',
+        default: './dist/index.mjs',
+      },
+      './feature': './dist/feature.mjs',
+      './legacy': null,
+    },
+    imports: {
+      '#internal': {
+        node: './src/internal-node.js',
+        default: './src/internal.js',
+      },
+    },
+    maintainers: [
+      {
+        name: 'npm maintainer',
+        email: 'maintainer@example.com',
+      },
+    ],
+  }
+
+  t.equal(pkg.type, 'module')
+  t.match(pkg.exports, { './feature': './dist/feature.mjs' })
+  t.match(pkg.imports, { '#internal': { default: './src/internal.js' } })
+  t.match(pkg.maintainers, [{ name: 'npm maintainer' }])
+  t.end()
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,12 @@ interface Funding {
   url: string
 }
 
+type PackageJSONExports =
+  | string
+  | string[]
+  | Record<string, string | string[] | PackageJSONExports>
+  | null
+
 // https://docs.npmjs.com/cli/v10/configuring-npm/package-json#overrides
 interface Overrides {
   [moduleName: string]: string | Overrides
@@ -125,6 +131,7 @@ export interface PackageJSON {
   licenses?: DeprecatedLicense | DeprecatedLicense[]
   main?: string
   man?: string | string[]
+  maintainers?: Contact[]
   name: string
   optionalDependencies?: Record<string, string>
   os?: string[]
@@ -137,6 +144,9 @@ export interface PackageJSON {
   scripts?: Record<string, string>
   // https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html#editing-the-packagejson
   types?: string
+  type?: 'commonjs' | 'module'
+  exports?: PackageJSONExports
+  imports?: Record<string, PackageJSONExports>
   version: string
   workspaces?: string[] | Record<string, string>
 


### PR DESCRIPTION
## Summary
- Add missing modern package metadata fields to `PackageJSON`: `type`, `exports`, `imports`, and `maintainers`.
- Add a regression test covering common conditional exports/imports and maintainer metadata.

## References
Closes #107

## Validation
- `npx tap test/package-json-fields.ts`
- `npm run eslint -- test/package-json-fields.ts types/index.d.ts`
- `git diff --check`